### PR TITLE
Use lstat instead of stat in fs_create.

### DIFF
--- a/backend/fs.c
+++ b/backend/fs.c
@@ -315,7 +315,7 @@ fs_create(void *softc, struct l9p_request *req)
 
 	asprintf(&newname, "%s/%s", file->name, req->lr_req.tcreate.name);
 
-	if (stat(file->name, &st) != 0) {
+	if (lstat(file->name, &st) != 0) {
 		l9p_respond(req, errno);
 		return;
 	}
@@ -414,7 +414,7 @@ fs_create(void *softc, struct l9p_request *req)
 		return;
 	}
 
-	if (stat(newname, &st) != 0) {
+	if (lstat(newname, &st) != 0) {
 		l9p_respond(req, errno);
 		return;
 	}


### PR DESCRIPTION
I was testing using your branch of xhyve with a rootfs over 9p. Something was creating a symlink into /dev/ as it was booting - and obviously on the OSX side that something wasn't there, hence this patch.
