### PR TITLE
use l9p_realloc to re-allocate receive buffer

### DIFF
--- a/transport/socket.c
+++ b/transport/socket.c
@@ -247,7 +247,7 @@ l9p_socket_readmsg(struct l9p_socket_softc *sc, void **buf, size_t *size)
 
 	msize = le32toh(*(uint32_t *)buffer);
 	toread = msize - sizeof(uint32_t);
-	buffer = realloc(buffer, msize);
+	buffer = l9p_realloc(buffer, msize);
 
 	ret = xread(fd, (char *)buffer + sizeof(uint32_t), toread);
 	if (ret < 0) {


### PR DESCRIPTION
When reading the code for transport/socket.c I noticed that in l9p_socket_readmsg(), you used l9p_malloc() to allocate the buffer space for reading the message size but then you used realloc() instead of l9p_realloc() when re-allocating the buffer to receive the rest of the message.

The bug that is fixed in this update is that the value of the buffer pointer is used without first checking to see if realloc() returned NULL.  Using l9p_realloc() takes care of this.