### PR TITLE
allow fsync on directories

### DIFF
--- a/backend/fs.c
+++ b/backend/fs.c
@@ -2411,7 +2411,7 @@ fs_fsync(void *softc __unused, struct l9p_request *req)
 
 	file = req->lr_fid->lo_aux;
 	assert(file);
-	if (fsync(file->ff_fd))
+	if (fsync(file->ff_dir != NULL ? dirfd(file->ff_dir) : file->ff_fd))
 		error = errno;
 	return (error);
 }

--- a/request.c
+++ b/request.c
@@ -1254,21 +1254,13 @@ l9p_dispatch_tfsync(struct l9p_request *req)
 	struct l9p_backend *be;
 	int error;
 
-	/*
-	 * Forbid dir?  Not clear what it means to fsync them.
-	 * Current backend code assumes open file (not dir),
-	 * so we'll forbid directories here for now.
-	 */
 	error = fid_lookup(conn, req->lr_req.hdr.fid, ENOENT,
-	    F_REQUIRE_OPEN | F_FORBID_DIR, &req->lr_fid);
+	    F_REQUIRE_OPEN, &req->lr_fid);
 	if (error)
 		return (error);
 
 	be = conn->lc_server->ls_backend;
 
-	/*
-	 * TODO: async fsync, maybe.
-	 */
 	error = be->fsync != NULL ? be->fsync(be->softc, req) : ENOSYS;
 	return (error);
 }


### PR DESCRIPTION
Linux does it; we need to pass the fsync down to the backend,
and the backend must handle directories.