### PR TITLE
request.c: Fix use of undeclared identifier 'ECAPMODE' on Darwin.

### DIFF
--- a/request.c
+++ b/request.c
@@ -319,7 +319,9 @@ e2linux(int errnum)
 		[ENOLINK] = LINUX_ENOLINK,
 		[EPROTO] = LINUX_EPROTO,
 		/* ENOTCAPABLE = unmappable? */
+#ifdef ECAPMODE
 		[ECAPMODE] = EPERM,
+#endif
 #ifdef ENOTRECOVERABLE
 		[ENOTRECOVERABLE] = LINUX_ENOTRECOVERABLE,
 #endif


### PR DESCRIPTION
Made ECAPMODE error mapping conditional.

Signed-off-by: John Coyle <dx9err@gmail.com>