### PR TITLE
pack.c: Fix clang11 compile 320:15: error: implicit conversion loses …

### DIFF
--- a/fcall.h
+++ b/fcall.h
@@ -251,7 +251,7 @@ struct l9p_hdr {
 };
 
 struct l9p_qid {
-	enum l9p_qid_type type;
+	uint8_t  type;
 	uint32_t version;
 	uint64_t path;
 };


### PR DESCRIPTION
…integer precision: 'enum l9p_qid_type' to 'uint8_t' (aka 'unsigned char')

Use uint8_t in l9p_qid struct instead of enum l9p_qid_type. The choice of enumerated type is implementation-defined. [1]

[1] http://c0x.coding-guidelines.com/6.7.2.2.html

Signed-off-by: John Coyle <dx9err@gmail.com>