### PR TITLE
Don't discard the const qualifier

### DIFF
--- a/example/server.c
+++ b/example/server.c
@@ -39,8 +39,8 @@ main(int argc, char **argv)
 {
 	struct l9p_backend *fs_backend;
 	struct l9p_server *server;
-	char *host = "0.0.0.0";
-	char *port = "564";
+	const char *host = "0.0.0.0";
+	const char *port = "564";
 	char *path;
 	bool ro = false;
 	int rootfd;


### PR DESCRIPTION
Without this change, clang complains:
error: initializing 'char *' with an expression of type 'const char [8]' discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]