### PR TITLE
Tunlinkat should handle an open directory fid

### DIFF
--- a/request.c
+++ b/request.c
@@ -1404,12 +1404,12 @@ l9p_dispatch_trenameat(struct l9p_request *req)
 	int error;
 
 	error = fid_lookup(conn, req->lr_req.hdr.fid, ENOENT,
-	    F_REQUIRE_DIR | F_FORBID_OPEN, &req->lr_fid);
+	    F_REQUIRE_DIR, &req->lr_fid);
 	if (error)
 		return (error);
 
 	error = fid_lookup(conn, req->lr_req.trenameat.newdirfid, ENOENT,
-	    F_REQUIRE_DIR | F_FORBID_OPEN, &req->lr_fid2);
+	    F_REQUIRE_DIR, &req->lr_fid2);
 	if (error)
 		return (error);
 
@@ -1428,7 +1428,7 @@ l9p_dispatch_tunlinkat(struct l9p_request *req)
 	int error;
 
 	error = fid_lookup(conn, req->lr_req.hdr.fid, ENOENT,
-	    F_REQUIRE_DIR | F_FORBID_OPEN, &req->lr_fid);
+	    F_REQUIRE_DIR, &req->lr_fid);
 	if (error)
 		return (error);
 


### PR DESCRIPTION
A user of bhyve in illumos, which uses a fork of this library, experienced a problem with unlinkat() on a 9p share. If the directory fd argument was for an open descriptor, EINVAL was returned.

This was seen when trying to do a recursive `rm -rf` on a 9p mount, mounted using 9p2000.L

```
testfs on /a type 9p (rw,relatime,dirsync,uname=root,mmap,access=client,trans=virtio,_netdev)

# cd /a
# mkdir -p aaaa/bbbb
# touch aaaa/bbbb/cccc
# rm -rf aaaa
rm: cannot remove 'aaaa': File exists
```
```
# strace rm -rf /a/aaaa 2>&1 | grep unlinkat
unlinkat(5, "cccc", 0)                  = -1 EINVAL (Invalid argument)
unlinkat(4, "bbbb", AT_REMOVEDIR)       = -1 EINVAL (Invalid argument)
unlinkat(AT_FDCWD, "/a/aaaa", AT_REMOVEDIR) = -1 EEXIST (File exists)                  <- note EEXIST here too.
```
```
[DEBUG]  l9p_dispatch_request: Treaddir tag=0 fid=5 offset=0 count=8168
...
DEBUG]  l9p_dispatch_request: Twalk tag=0 fid=5 newfid=6 wname="cccc" 
[DEBUG]  open_fid: authinfo 1290a50 now used by 6
...
[DEBUG]  l9p_dispatch_request: Tunlinkat tag=0 dirfd=5 name="cccc" flags=0x0
[DEBUG]  l9p_respond: Rlerror tag=0 errnum=22 (Invalid argument)
```

These tests are from a Fedora 35 guest in illumos bhyve.
When using unlinkat() with a directory opened with Linux's O_PATH, it succeeds:

```
        fd = open("/a", O_RDONLY | O_DIRECTORY | O_PATH);
        r = unlinkat(fd, "cccc", 0);
        printf("Ret %d errno %d\n", r, errno);
...
# ./test
Ret 0 errno 0
```

but without it generates EINVAL:

```
        fd = open("/a", O_RDONLY | O_DIRECTORY);
        r = unlinkat(fd, "cccc", 0);
        printf("Ret %d errno %d\n", r, errno);
...
# ./test
Ret -1 errno 22
```

Using AT_FDCWD also works:

```
        r = unlinkat(AT_FDCWD, "cccc", 0);
        printf("Ret %d errno %d\n", r, errno);
...
# cd /a; ./test
Ret 0 errno 0
```

The constraint in Tunlinkat() that the directory file descriptor is not open seems wrong.